### PR TITLE
fix #10 - Compilation fails on other architectures than STM32

### DIFF
--- a/src/dirzctl.c
+++ b/src/dirzctl.c
@@ -1,3 +1,4 @@
+#include "autoconf.h" // CONFIG_CLOCK_FREQ
 #include "basecmd.h"        // oid_alloc
 #include "board/gpio.h"     // struct gpio_in
 #include "board/irq.h"      // irq_disable

--- a/src/hx711s.c
+++ b/src/hx711s.c
@@ -1,3 +1,4 @@
+#include "autoconf.h" // CONFIG_CLOCK_FREQ
 #include "basecmd.h"        // oid_alloc
 #include "board/gpio.h"     // struct gpio_in
 #include "board/irq.h"      // irq_disable


### PR DESCRIPTION
Added 
#include "autoconf.h" to src/dirzctl.c and src/hx711s.c 

Without it CONFIG_CLOCK_FREQ is unknown to both files and compiling of additional MCUs (f.e. RP2040) fails.

Successfully compiled on:
(X) Atmega AVR
(X) SAM3/SAM4/SAM E70 (Due and Duet)
(X) SAMC21/SAMD21/SAMD51/SAME5x
(X) LPC176x (Smoothieboard)
(X) STMicroelectronics STM32
(X) Huada Semiconductor HC32F460
(X) Raspberry Pi RP2040
( ) Beaglebone PRU
( ) Allwinner A64 AR100
(X) Linux process
( ) Host simulator

Seen the following errors when compiling the failed once (but I get the same error if I compile your fork without my changes, so not introduced by my edition):
Beagle: make: pru-gcc: Permission denied
Allwinner: make: or1k-linux-musl-gcc: Permission denied
Host simulator: src/dirzctl.c:6:10: fatal error: board/internal.h: No such file or directory

